### PR TITLE
fix: ensure local storage sync for note content updates

### DIFF
--- a/app/boards/[id]/notes/[noteId]/components/Editor.tsx
+++ b/app/boards/[id]/notes/[noteId]/components/Editor.tsx
@@ -21,6 +21,8 @@ export default function Editor({ noteId, onUpdate }: EditorType) {
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newContent = event.target.value;
+    localStorage.setItem(`note-${noteId}`, newContent);
+    if (newContent === markdown) return;
     saveContent(newContent);
   };
 
@@ -43,6 +45,18 @@ export default function Editor({ noteId, onUpdate }: EditorType) {
       setIsClient(true);
     };
     loadNote();
+
+    window.addEventListener('storage', (event) => {
+      if (event.key === `note-${noteId}`) {
+        const storedContent = localStorage.getItem(`note-${noteId}`);
+        if (storedContent !== null) {
+          setMarkdown(storedContent);
+          if (textareaRef.current) {
+            textareaRef.current.value = storedContent;
+          }
+        }
+      }
+    });
   }, [noteId]);
 
   const renderMarkdownToHtml = (markdown: string) => {


### PR DESCRIPTION
This pull request introduces functionality to sync note content between browser tabs using the `localStorage` API in the `Editor` component. The changes ensure that updates to a note's content are stored locally and reflected across tabs in real time.

### Synchronization of note content across browser tabs:

* `app/boards/[id]/notes/[noteId]/components/Editor.tsx`: Added logic to save the note content to `localStorage` whenever it changes (`handleChange` method). ([app/boards/[id]/notes/[noteId]/components/Editor.tsxR24-R25](diffhunk://#diff-a0b5364df5497aec158ddb98c1c76ced9dee939c6f37f845a3326916e6a2ef31R24-R25))
* `app/boards/[id]/notes/[noteId]/components/Editor.tsx`: Added a `storage` event listener to detect changes in `localStorage` and update the editor's content accordingly. This ensures that the note content is synchronized across browser tabs (`useEffect` hook). ([app/boards/[id]/notes/[noteId]/components/Editor.tsxR48-R59](diffhunk://#diff-a0b5364df5497aec158ddb98c1c76ced9dee939c6f37f845a3326916e6a2ef31R48-R59))