### PR TITLE
feat: implement masonry layout for HomeTabs component to enhance note…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,3 +26,28 @@ body {
 .nav-pills .show > .nav-link {
   background-color: transparent;
 }
+
+.masonry-container {
+  column-count: 1;
+  column-gap: 16px;
+}
+
+.masonry-container .masonry-item {
+  display: inline-block;
+  width: 100%;
+  margin-bottom: 16px;
+  break-inside: avoid;
+}
+
+/* Responsive columns */
+@media (min-width: 600px) {
+  .masonry-container {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 900px) {
+  .masonry-container {
+    column-count: 3;
+  }
+}

--- a/app/partials/HomeTabs.tsx
+++ b/app/partials/HomeTabs.tsx
@@ -159,14 +159,14 @@ export default function HomeTabs({
               aria-labelledby={`tab-${board.id}`}
               key={board.id}
             >
-              <div className="row">
+              <div className="masonry-container">
                 {loadingNotes ? (
                   <Loader caption="Loading notes..." />
                 ) : notes && notes.length > 0 ? (
                   notes.map(
                     (note) =>
                       note.boardsId === board.id && (
-                        <div className="col-md-3" key={note.id}>
+                        <div className="masonry-item" key={note.id}>
                           <div className="card mb-2">
                             {note.imageUrl && (
                               <Link


### PR DESCRIPTION
This pull request introduces a responsive masonry-style layout for displaying notes in the `HomeTabs` component, replacing the previous grid-based approach. The main changes involve new CSS rules and updated markup to support this layout.

**Layout and Styling Improvements:**

* Added `.masonry-container` and `.masonry-item` CSS classes in `app/globals.css` to create a masonry effect using CSS columns, including responsive adjustments for different screen sizes.

**Component Structure Updates:**

* Updated `app/partials/HomeTabs.tsx` to use the new `.masonry-container` and `.masonry-item` classes for rendering notes, replacing the old Bootstrap grid (`row` and `col-md-3`) structure.

Closes #26 