### PR TITLE
Add Prisma migration for Share and ShareView tables

### DIFF
--- a/prisma/migrations/20260413190000_shared_tables/migration.sql
+++ b/prisma/migrations/20260413190000_shared_tables/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "Share" (
+    "id" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" INTEGER NOT NULL,
+    "password" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "oneTime" BOOLEAN NOT NULL DEFAULT false,
+    "viewCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Share_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ShareView" (
+    "id" SERIAL NOT NULL,
+    "shareId" TEXT NOT NULL,
+    "viewerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ShareView_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Share_entityId_entityType_idx" ON "Share"("entityId", "entityType");
+
+-- CreateIndex
+CREATE INDEX "ShareView_shareId_idx" ON "ShareView"("shareId");
+
+-- CreateIndex
+CREATE INDEX "ShareView_viewerId_idx" ON "ShareView"("viewerId");
+
+-- AddForeignKey
+ALTER TABLE "ShareView" ADD CONSTRAINT "ShareView_shareId_fkey" FOREIGN KEY ("shareId") REFERENCES "Share"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
### Motivation
- Introduce persistent tables to support the sharing feature and track share views across entities (boards/notes).

### Description
- Add new migration file `prisma/migrations/20260413190000_shared_tables/migration.sql` that creates a `Share` table with primary key and fields for entity type/id, password, expiry, counters, and timestamps. 
- Create a `ShareView` table to record individual views with a reference to `Share` and a timestamp. 
- Add indexes on `Share(entityId, entityType)`, `ShareView(shareId)`, and `ShareView(viewerId)`, and add a cascading foreign key from `ShareView.shareId` to `Share.id`.

### Testing
- Ran `npx prisma validate`, which failed without an environment `DATABASE_URL` and returned the missing env error. 
- Ran `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/daylog?schema=public' npx prisma validate`, which succeeded and reported the schema as valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2cd5c220832495bed1a0f3b035e8)