### PR TITLE
feat: replace in-memory collab state with Redis for multi-instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,11 @@ SHOW_SPONSOR_FOOTER='true'
 # Field encryption master key — required to enable per-user encryption
 # Generate with: openssl rand -hex 32
 #ENCRYPTION_MASTER_KEY='your_64_char_hex_key_here'
+
+# Redis — required for real-time collaborative editing
+# Self-hosted:  REDIS_URL='redis://localhost:6379'
+# With auth:    REDIS_URL='redis://:yourpassword@localhost:6379'
+# TLS (Upstash, Redis Cloud, etc.): REDIS_URL='rediss://:yourpassword@host:port'
+REDIS_URL='redis://redis:6379' # matches the docker-compose service name
+#REDIS_URL='redis://localhost:6379' # if running the app outside Docker
+# TLS (Upstash, Redis Cloud, etc.): REDIS_URL='rediss://:yourpassword@host:port'

--- a/app/api/v1/notes/[noteId]/stream/route.ts
+++ b/app/api/v1/notes/[noteId]/stream/route.ts
@@ -6,14 +6,16 @@ import { getCurrentSession } from '@/app/login/lib/actions';
 import { prisma } from '@/prisma/client';
 import { NextRequest } from 'next/server';
 import {
-  getOrCreateRoom,
-  broadcastToRoom,
-  deleteRoom,
+  getOrInitRoom,
+  getAllPresence,
+  removePresence,
+  publishEvent,
   formatSSE,
-  getRoomPresence,
+  eventsChannel,
   loadNoteRoomContent,
+  type CollabEvent,
 } from '@/lib/noteCollaboration';
-import { randomUUID } from 'crypto';
+import { createSubscriber } from '@/lib/redis';
 
 async function hasNoteAccess(noteId: number, userId: number): Promise<boolean> {
   const asOwner = await prisma.note.findFirst({
@@ -51,54 +53,88 @@ export async function GET(
     return Response.json({ error: 'Not allowed' }, { status: 403 });
   }
 
-  const userName = user.name ?? user.email ?? 'Unknown';
-
   const sessionToken = req.cookies.get('session')?.value;
-  const room = await getOrCreateRoom(noteId, () =>
+  const { content, revision } = await getOrInitRoom(noteId, () =>
     loadNoteRoomContent(noteId, sessionToken),
   );
+  const presence = await getAllPresence(noteId);
 
-  const connectionId = randomUUID();
+  // Each SSE connection gets its own Redis subscriber connection.
+  const subscriber = createSubscriber();
+  const pendingSSE: string[] = [];
+  let streamController: ReadableStreamDefaultController | null = null;
+
+  // Set up the message handler before subscribing to avoid missing events
+  // that arrive between subscribe() and the ReadableStream start() call.
+  subscriber.on('message', (_channel, rawMessage) => {
+    try {
+      const event = JSON.parse(rawMessage) as CollabEvent;
+      const sseStr = formatSSE(event.type, event.data);
+      if (streamController) {
+        try {
+          streamController.enqueue(sseStr);
+        } catch {
+          // Stream closed; cleanup will fire via cancel()
+        }
+      } else {
+        pendingSSE.push(sseStr);
+      }
+    } catch {
+      // Ignore malformed Redis messages
+    }
+  });
+
+  await subscriber.subscribe(eventsChannel(noteId));
+
   let pingInterval: ReturnType<typeof setInterval> | null = null;
+
+  const cleanup = async () => {
+    if (pingInterval) {
+      clearInterval(pingInterval);
+      pingInterval = null;
+    }
+    try {
+      await subscriber.unsubscribe();
+      subscriber.quit();
+    } catch {
+      // Ignore errors on teardown
+    }
+    await removePresence(noteId, user.id);
+    await publishEvent(noteId, { type: 'leave', data: { userId: user.id } });
+  };
 
   const stream = new ReadableStream({
     start(controller) {
-      room.connections.set(connectionId, {
-        id: connectionId,
-        userId: user.id,
-        userName,
-        controller,
-      });
+      streamController = controller;
 
-      // Send initial state
+      // Drain any events that arrived before start() was called
+      for (const msg of pendingSSE.splice(0)) {
+        try {
+          controller.enqueue(msg);
+        } catch {
+          // ignore
+        }
+      }
+
+      // Send initial state (exclude self from presence)
+      const presenceWithoutSelf = Object.fromEntries(
+        Object.entries(presence).filter(([uid]) => parseInt(uid) !== user.id),
+      );
       controller.enqueue(
-        formatSSE('init', {
-          revision: room.revision,
-          content: room.content,
-          presence: getRoomPresence(room),
-        }),
+        formatSSE('init', { revision, content, presence: presenceWithoutSelf }),
       );
 
-      // Keep-alive ping every 30 seconds; also detects dead connections
+      // Keep-alive ping every 30 s; also detects dead connections
       pingInterval = setInterval(() => {
         try {
           controller.enqueue(formatSSE('ping', {}));
         } catch {
-          // Client disconnected without a clean close — evict it now
-          if (pingInterval) clearInterval(pingInterval);
-          room.connections.delete(connectionId);
-          room.presence.delete(user.id);
-          broadcastToRoom(noteId, { type: 'leave', data: { userId: user.id } });
-          if (room.connections.size === 0) deleteRoom(noteId);
+          void cleanup();
         }
       }, 30_000);
     },
     cancel() {
-      if (pingInterval) clearInterval(pingInterval);
-      room.connections.delete(connectionId);
-      room.presence.delete(user.id);
-      broadcastToRoom(noteId, { type: 'leave', data: { userId: user.id } });
-      if (room.connections.size === 0) deleteRoom(noteId);
+      return cleanup();
     },
   });
 

--- a/app/api/v1/notes/[noteId]/sync/route.ts
+++ b/app/api/v1/notes/[noteId]/sync/route.ts
@@ -1,7 +1,13 @@
 import { getCurrentSession } from '@/app/login/lib/actions';
 import { prisma } from '@/prisma/client';
 import { NextRequest } from 'next/server';
-import { getOrCreateRoom, broadcastToRoom, loadNoteRoomContent } from '@/lib/noteCollaboration';
+import {
+  getOrInitRoom,
+  updateRoomContent,
+  setPresence,
+  publishEvent,
+  loadNoteRoomContent,
+} from '@/lib/noteCollaboration';
 import { computeDiff, applyPatch } from '@/utils/diff';
 
 const MAX_PATCH_SIZE = 64 * 1024; // 64 KB
@@ -59,23 +65,12 @@ export async function POST(
       return Response.json({ error: 'Invalid line' }, { status: 400 });
     }
 
-    const room = await getOrCreateRoom(noteId, () =>
-      loadNoteRoomContent(noteId, req.cookies.get('session')?.value),
-    );
-
     const userName = user.name ?? user.email ?? 'Unknown';
-    room.presence.set(user.id, {
-      userId: user.id,
-      userName,
-      line,
-      updatedAt: Date.now(),
+    await setPresence(noteId, user.id, userName, line);
+    await publishEvent(noteId, {
+      type: 'presence',
+      data: { userId: user.id, userName, line },
     });
-
-    broadcastToRoom(
-      noteId,
-      { type: 'presence', data: { userId: user.id, userName, line } },
-      user.id,
-    );
 
     return Response.json({ ok: true });
   }
@@ -99,51 +94,40 @@ export async function POST(
       return Response.json({ error: 'Patch too large' }, { status: 413 });
     }
 
-    const room = await getOrCreateRoom(noteId, () =>
-      loadNoteRoomContent(noteId, req.cookies.get('session')?.value),
+    const sessionToken = req.cookies.get('session')?.value;
+    const { content, revision } = await getOrInitRoom(noteId, () =>
+      loadNoteRoomContent(noteId, sessionToken),
     );
 
     let newContent: string | null = null;
-
-    if (baseRevision === room.revision) {
-      newContent = applyPatch(room.content, patch);
-    } else if (baseRevision < room.revision) {
-      // Try fuzzy OT: apply the patch on top of current content
-      newContent = applyPatch(room.content, patch);
+    if (baseRevision === revision || baseRevision < revision) {
+      newContent = applyPatch(content, patch);
     }
 
     if (newContent === null) {
       // Patch failed — tell client to hard-resync
-      return Response.json({
-        ok: false,
-        content: room.content,
-        revision: room.revision,
-      });
+      return Response.json({ ok: false, content, revision });
     }
 
-    // Only update if content actually changed
-    if (newContent !== room.content) {
-      // Compute the effective patch from current content to new content for broadcasting
-      const effectivePatch = computeDiff(room.content, newContent);
-      room.content = newContent;
-      room.revision += 1;
+    if (newContent !== content) {
+      const effectivePatch = computeDiff(content, newContent);
+      const newRevision = revision + 1;
 
-      broadcastToRoom(
-        noteId,
-        {
-          type: 'content',
-          data: {
-            revision: room.revision,
-            content: room.content,
-            patch: effectivePatch,
-            authorId: user.id,
-          },
+      await updateRoomContent(noteId, newContent, newRevision);
+      await publishEvent(noteId, {
+        type: 'content',
+        data: {
+          revision: newRevision,
+          content: newContent,
+          patch: effectivePatch,
+          authorId: user.id,
         },
-        user.id,
-      );
+      });
+
+      return Response.json({ ok: true, revision: newRevision });
     }
 
-    return Response.json({ ok: true, revision: room.revision });
+    return Response.json({ ok: true, revision });
   }
 
   return Response.json({ error: 'Unknown type' }, { status: 400 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,20 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    container_name: daylog-redis
+    restart: always
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redis:/data
+
   app:
     build:
       context: .
@@ -27,15 +41,18 @@ services:
     container_name: daylog-app
     ports:
       - 3000:3000
-    env_file: 
+    env_file:
       - .env
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     volumes:
       - storage:/app/storage
 
 volumes:
   data:
+  redis:
   storage:
     driver: local

--- a/lib/noteCollaboration.test.ts
+++ b/lib/noteCollaboration.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { loadNoteRoomContent } from './noteCollaboration';
+
+vi.mock('./redis', () => ({ redis: {}, createSubscriber: vi.fn() }));
 import {
   deriveEncryptionKey,
   encryptField,

--- a/lib/noteCollaboration.ts
+++ b/lib/noteCollaboration.ts
@@ -5,27 +5,13 @@ import {
   getSessionEncryptionKey,
   isEncrypted,
 } from '@/utils/encryption';
-
-export interface CollabConnection {
-  id: string;
-  userId: number;
-  userName: string;
-  controller: ReadableStreamDefaultController;
-}
+import { redis } from './redis';
 
 export interface CollabPresence {
   userId: number;
   userName: string;
   line: number;
   updatedAt: number;
-}
-
-export interface CollabRoom {
-  content: string;
-  revision: number;
-  connections: Map<string, CollabConnection>;
-  presence: Map<number, CollabPresence>;
-  initPromise: Promise<string>;
 }
 
 export type CollabEventType = 'init' | 'content' | 'presence' | 'leave' | 'ping';
@@ -35,9 +21,12 @@ export interface CollabEvent {
   data: Record<string, unknown>;
 }
 
-const g = globalThis as typeof globalThis & { __noteRooms?: Map<number, CollabRoom> };
-if (!g.__noteRooms) g.__noteRooms = new Map();
-const noteRooms = g.__noteRooms;
+const ROOM_TTL_S = 7 * 24 * 60 * 60; // 7 days
+const PRESENCE_TTL_S = 24 * 60 * 60; // 1 day
+
+export const eventsChannel = (noteId: number) => `collab:events:${noteId}`;
+const roomKey = (noteId: number) => `collab:room:${noteId}`;
+const presenceKey = (noteId: number) => `collab:presence:${noteId}`;
 
 /**
  * Loads the plaintext content of a note for a collaboration room. Rooms always
@@ -85,57 +74,98 @@ export async function loadNoteRoomContent(
   return content;
 }
 
-export async function getOrCreateRoom(
+/**
+ * Returns the current room state from Redis, loading from the DB via
+ * contentLoader if the key does not exist yet. Uses HSETNX so concurrent
+ * connections racing to initialize the same room are safe.
+ */
+export async function getOrInitRoom(
   noteId: number,
   contentLoader: () => Promise<string>,
-): Promise<CollabRoom> {
-  if (noteRooms.has(noteId)) {
-    const room = noteRooms.get(noteId)!;
-    await room.initPromise;
-    return room;
+): Promise<{ content: string; revision: number }> {
+  const key = roomKey(noteId);
+  const existing = await redis.hgetall(key);
+
+  if (existing && Object.keys(existing).length > 0) {
+    return {
+      content: existing.content ?? '',
+      revision: parseInt(existing.revision ?? '0', 10),
+    };
   }
 
-  const initPromise = contentLoader();
-  const room: CollabRoom = {
-    content: '',
-    revision: 0,
-    connections: new Map(),
-    presence: new Map(),
-    initPromise,
-  };
-  noteRooms.set(noteId, room);
+  const content = await contentLoader();
+  const won = await redis.hsetnx(key, 'content', content);
+  if (won) {
+    await redis.hset(key, 'revision', '0');
+    await redis.expire(key, ROOM_TTL_S);
+    return { content, revision: 0 };
+  }
 
-  room.content = await initPromise;
-  return room;
+  // Another instance initialised the room first — read their state.
+  const final = await redis.hgetall(key);
+  return {
+    content: final.content ?? content,
+    revision: parseInt(final.revision ?? '0', 10),
+  };
 }
 
-export function broadcastToRoom(
+export async function getRoomState(
   noteId: number,
-  event: CollabEvent,
-  excludeUserId?: number,
-): void {
-  const room = noteRooms.get(noteId);
-  if (!room) return;
+): Promise<{ content: string; revision: number } | null> {
+  const data = await redis.hgetall(roomKey(noteId));
+  if (!data || Object.keys(data).length === 0) return null;
+  return {
+    content: data.content ?? '',
+    revision: parseInt(data.revision ?? '0', 10),
+  };
+}
 
-  const message = formatSSE(event.type, event.data);
-  for (const conn of room.connections.values()) {
-    if (excludeUserId !== undefined && conn.userId === excludeUserId) continue;
+export async function updateRoomContent(
+  noteId: number,
+  content: string,
+  revision: number,
+): Promise<void> {
+  const key = roomKey(noteId);
+  await redis.hset(key, 'content', content, 'revision', String(revision));
+  await redis.expire(key, ROOM_TTL_S);
+}
+
+export async function setPresence(
+  noteId: number,
+  userId: number,
+  userName: string,
+  line: number,
+): Promise<void> {
+  const key = presenceKey(noteId);
+  const entry: CollabPresence = { userId, userName, line, updatedAt: Date.now() };
+  await redis.hset(key, String(userId), JSON.stringify(entry));
+  await redis.expire(key, PRESENCE_TTL_S);
+}
+
+export async function removePresence(noteId: number, userId: number): Promise<void> {
+  await redis.hdel(presenceKey(noteId), String(userId));
+}
+
+export async function getAllPresence(
+  noteId: number,
+): Promise<Record<string, CollabPresence>> {
+  const data = await redis.hgetall(presenceKey(noteId));
+  if (!data) return {};
+  const result: Record<string, CollabPresence> = {};
+  for (const [uid, json] of Object.entries(data)) {
     try {
-      conn.controller.enqueue(message);
+      result[uid] = JSON.parse(json) as CollabPresence;
     } catch {
-      // Connection is closed; will be cleaned up on abort
+      // skip malformed entry
     }
   }
+  return result;
+}
+
+export async function publishEvent(noteId: number, event: CollabEvent): Promise<void> {
+  await redis.publish(eventsChannel(noteId), JSON.stringify(event));
 }
 
 export function formatSSE(event: string, data: Record<string, unknown>): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-}
-
-export function getRoomPresence(room: CollabRoom): Record<number, CollabPresence> {
-  return Object.fromEntries(room.presence.entries());
-}
-
-export function deleteRoom(noteId: number): void {
-  noteRooms.delete(noteId);
 }

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,16 @@
+import Redis from 'ioredis';
+
+const url = process.env.REDIS_URL;
+if (!url) throw new Error('REDIS_URL environment variable is not set');
+
+const g = globalThis as typeof globalThis & { __redis?: Redis };
+if (!g.__redis) {
+  g.__redis = new Redis(url, { maxRetriesPerRequest: 3 });
+}
+export const redis = g.__redis;
+
+// Each SSE connection needs its own subscriber connection — ioredis blocks a
+// connection in subscriber mode, so it cannot issue regular commands.
+export function createSubscriber(): Redis {
+  return new Redis(url!, { maxRetriesPerRequest: null, enableReadyCheck: false });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "diff-match-patch": "^1.0.5",
         "framer-motion": "^12.34.3",
         "input-otp": "^1.4.2",
+        "ioredis": "^5.11.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.575.0",
         "marked": "^15.0.3",
@@ -2446,6 +2447,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -7333,6 +7340,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7619,6 +7635,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dequal": {
@@ -9604,6 +9629,28 @@
       "dependencies": {
         "@formatjs/fast-memoize": "3.1.6",
         "@formatjs/icu-messageformat-parser": "3.5.11"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/is-alphabetical": {
@@ -12820,6 +12867,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -13683,6 +13751,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "diff-match-patch": "^1.0.5",
     "framer-motion": "^12.34.3",
     "input-otp": "^1.4.2",
+    "ioredis": "^5.11.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.575.0",
     "marked": "^15.0.3",


### PR DESCRIPTION
Real-time collaboration previously stored room state in globalThis, which breaks on Vercel where each serverless instance has its own memory. State is now kept in Redis Hashes and events are broadcast via Redis pub/sub, so all instances share a consistent view of every document.

- Add lib/redis.ts: ioredis singleton + createSubscriber() factory
- Rewrite lib/noteCollaboration.ts: room state and presence in Redis, publishEvent() replaces broadcastToRoom()
- Rewrite stream route: each SSE connection subscribes to its Redis channel
- Rewrite sync route: reads/writes state from Redis, publishes events
- Add Redis service to docker-compose.yml with healthcheck and volume
- Update .env.example with REDIS_URL examples for Docker and Upstash
- Mock lib/redis in noteCollaboration.test.ts so tests run without REDIS_URL